### PR TITLE
Added option to skip highlighting inline code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Add syntax highlighter to a single markdown source using the given options:
   // Can be any of
   // https://github.com/octref/shiki/tree/master/packages/themes
   // and will default to 'nord'
-  theme: 'nord'
+  theme: 'nord',
+  
+  // Set to `true` to skip highlighting inline `code` elements.
+  skipInline: false
 }
 ```
 
@@ -42,7 +45,7 @@ module.exports = {
 }
 ```
 
-Add syntax highlighter to all markdown sources:
+Add syntax highlighter to all markdown sources, but skip inline code:
 
 ```js
 module.exports = {
@@ -56,7 +59,7 @@ module.exports = {
   transformers: {
     remark: {
       plugins: [
-        [ 'gridsome-plugin-remark-shiki', { theme: 'nord' } ]
+        [ 'gridsome-plugin-remark-shiki', { theme: 'nord', skipInline: true } ]
       ]
     }
   }

--- a/index.js
+++ b/index.js
@@ -31,14 +31,16 @@ module.exports = (options) => {
       }
     })
 
-    visit(tree, 'inlineCode', node => {
-      node.type = 'html'
-      try {
-        node.value = highlight(node, CLASS_INLINE, highlighter)
-      } catch (e) {
-        node.value = ERROR_MESSAGE
-      }
-    })
+    if (!options.skipInline) {
+      visit(tree, 'inlineCode', node => {
+        node.type = 'html'
+        try {
+          node.value = highlight(node, CLASS_INLINE, highlighter)
+        } catch (e) {
+          node.value = ERROR_MESSAGE
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
In the site I'm working on it looks weird to have multicolored code fragments in the middle of paragraph text, so I added an option to skip inline code highlighting.

I considered adding a parallel option to skip block code highlighting, but I couldn't imagine wanting to highlight inline code and *not* code blocks, so I held off.