### PR TITLE
Advcanced Syntax Highlighting API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install gridsome-plugin-remark-shiki
 
 ## Usage
 
+### With a single markdown source
+
 Add syntax highlighter to a single markdown source using the given options:
 
 ```js
@@ -34,6 +36,8 @@ module.exports = {
 }
 ```
 
+### With all markdown sources
+
 Add syntax highlighter to all markdown sources, but skip inline code:
 
 ```js
@@ -54,6 +58,8 @@ module.exports = {
   }
 }
 ```
+
+### Using custom themes
 
 Use custom themes with the syntax highlighter:
 
@@ -80,7 +86,7 @@ module.exports = {
 }
 ```
 
-Use with [@gridsome/vue-remark](https://gridsome.org/plugins/@gridsome/vue-remark):
+### With [@gridsome/vue-remark](https://gridsome.org/plugins/@gridsome/vue-remark)
 
 ```js
 module.exports = {
@@ -102,3 +108,120 @@ module.exports = {
   ],
 };
 ```
+
+## Features
+
+The following options are available for this plugin:
+
+```js
+{
+  // declare a theme for syntax highlighting
+  theme: 'nord',
+  // skip the inline code elements (default: false)
+  skipInline: true,
+  // display language of the highlighted code (default: false)
+  showLanguage: true,
+  // display line numbers (default: false)
+  showLineNumbers: true,
+  // enable line highlighting (default: false)
+  highlightLines: true,
+  // set aliases
+  aliases: {
+    dockerfile: 'docker',
+    yml: 'yaml'
+  }
+}
+```
+
+### Display language
+
+When `showLanguage` is `true`, the plugin will add a block displaying the language as follows:
+
+```html
+<div class="code-metadata"><span class="language-id">js</span></div>
+<pre class="shiki" tabindex="0"><code><!-- highlighted code --></code></pre>
+```
+
+You can write CSS to customize how you want to display `code-metadata`, e.g.,
+
+```css
+.code-metadata {
+  user-select: none; /* disable copying metadata while copying the code from the code block */
+  margin-bottom: 1ch;
+}
+
+.code-metadata .language-id {
+  padding: 0.25em 0.5em;
+  background-color: blue;
+  color: white;
+  border-radius: 0.25em;
+}
+```
+
+> Note that the language will be shown only when it is [specified in the codeblock metadata](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting).
+
+### Display line numbers
+
+When `showLineNumbers` is `true`, the plugin will display the line numbers alongside each line.
+
+```html
+<pre class="shiki" tabindex="0">
+  <code>
+    <span class="line">
+      <span class="line-number" aria-hidden="true">1</span>
+      <span>console.log('Hello, world');</span>
+    </span>
+    <span class="line">
+      <span class="line-number" aria-hidden="true">2</span>
+      <span>console.log('This codeblock is displayed with line numbers!');</span>
+    </span>
+  </code>
+</pre>
+```
+
+You can write custom CSS to control how the line numbers would look, e.g.,
+
+```css
+.shiki .line .line-number {
+  display: inline-block;
+  user-select: none; /* disable copying line numbers while copying the code from the code block */
+  padding-inline-end: 2ch;
+  text-align: right;
+  opacity: 0.6;
+}
+```
+
+> Note that line numbers will not be displayed for codeblocks of single line.
+
+### Highlight lines
+
+When `highlightLines` is `true`, you can specify the lines to highlight in code block's metadata. This could be a series or range of line numbers, e.g.,
+
+<pre>
+```js {2}
+console.log('Hello, world!')
+console.log('Behold the highlighted line!')
+```
+
+```js {1,3-4}
+console.log('Hello, world! This is highlighted line!')
+console.log('Your code is not your life.')
+console.log('Behold another highlighted line!')
+console.log('And yet another highlighted line!')
+```
+</pre>
+
+### Aliases
+
+If Shiki does not support highlighting your language or the language identifier that you used is different from what Shiki uses, you can alias them as follows to force syntax highlighting.
+
+```js
+aliases: {
+  dockerfile: 'docker',
+  yml: 'yaml'
+}
+```
+
+### Dark Mode support
+
+Shiki provides multiple ways to support Dark Mode. Refer to the documentation here: <https://github.com/shikijs/shiki/blob/main/docs/themes.md#dark-mode-support>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "gridsome-plugin-remark-shiki",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.5.0",
+      "version": "0.7.0",
       "dependencies": {
-        "shiki": "^0.2.6",
-        "shiki-languages": "^0.2.6",
-        "unist-util-visit": "^2.0.1"
+        "parse-numeric-range": "^1.3.0",
+        "shiki": "^0.9.10",
+        "unist-util-visit": "^2.0.3"
       },
       "devDependencies": {
         "eslint": "^6.8.0",
@@ -1117,8 +1117,9 @@
       "license": "MIT"
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "license": "MIT",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -1128,10 +1129,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json5/node_modules/minimist": {
-      "version": "1.2.5",
-      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.3.0",
@@ -1178,7 +1175,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mkdirp": {
@@ -1272,6 +1268,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -1408,28 +1409,13 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.2.6",
-      "license": "MIT",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "dependencies": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.6",
-        "shiki-themes": "^0.2.6",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-languages": {
-      "version": "0.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "node_modules/shiki-themes": {
-      "version": "0.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/signal-exit": {
@@ -2490,14 +2476,11 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5"
-        }
       }
     },
     "levn": {
@@ -2530,8 +2513,7 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "dev": true
+      "version": "1.2.5"
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -2598,6 +2580,11 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2677,25 +2664,13 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.2.6",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "requires": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.6",
-        "shiki-themes": "^0.2.6",
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-languages": {
-      "version": "0.2.6",
-      "requires": {
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-themes": {
-      "version": "0.2.6",
-      "requires": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "name": "gridsome-plugin-remark-shiki",
   "description": "Shiki for Gridsome",
   "homepage": "https://github.com/EldoranDev/gridsome-plugin-remark-shiki/blob/develop/README.md",
@@ -15,9 +15,9 @@
     "remark"
   ],
   "dependencies": {
-    "shiki": "^0.2.6",
-    "shiki-languages": "^0.2.6",
-    "unist-util-visit": "^2.0.1"
+    "parse-numeric-range": "^1.3.0",
+    "shiki": "^0.9.10",
+    "unist-util-visit": "^2.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,51 @@
+const htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+}
+
+const escapeHtml = html => html.replace(/[&<>"']/g, chr => htmlEscapes[chr])
+
+const renderToHtml = (lines, options) => {
+  const fg = options.fg
+  const bg = options.bg || '#fff'
+
+  let html = ''
+
+  if (options.langId) {
+    html += `<div class="code-metadata">`
+    html += `<span class="language-id">${options.langId}</span>`
+    html += `</div>`
+  }
+
+  html += `<pre class="shiki" tabindex="0" style="background-color: ${bg}">`
+  html += `<code>`
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1
+
+    if (options.linesToHighlight && options.linesToHighlight.includes(lineNumber)) {
+      html += `<span class="line line-highlighted">`
+    } else {
+      html += `<span class="line">`
+    }
+
+    if (options.showLineNumbers) {
+      html += `<span class="line-number" aria-hidden="true">${options.lineNumberFormatter(lineNumber)}</span>`
+    }
+
+    line.forEach(token => {
+      const cssDeclarations = [`color: ${token.color || fg}`]
+      html += `<span style="${cssDeclarations.join('; ')}">${escapeHtml(token.content)}</span>`
+    })
+    html += `</span>\n`
+  })
+  html = html.replace(/\n*$/, '') // Get rid of final new lines
+  html += `</code></pre>`
+
+  return html
+}
+
+module.exports = { renderToHtml }


### PR DESCRIPTION
This change introduces the following:

- **Display line numbers** (requires custom CSS)
- **Highlight lines** (requires custom CSS)
- **Display language** along with highlighted code (requires custom CSS)
- **Support for aliases**
- **Accessibility improvements** `pre` block is now keyboard navigable
- Examples on how to use all of the above features
- Upgrade to the latest version of Shiki that brings Dark Mode and additional language support

@EldoranDev Let me know what do you think about this. I wrote a custom renderer to enable these features. Note that the highlighting syntax in this change is aligned toward [gatsby-remark-vscode](https://github.com/andrewbranch/gatsby-remark-vscode) rather than the [Decoration API](https://github.com/shikijs/shiki/issues/5). Also, you can see this in action on my blog: https://mflash.dev/